### PR TITLE
feat: add daily and monthly report placeholders

### DIFF
--- a/web-admin/app/pages/reports/daily.vue
+++ b/web-admin/app/pages/reports/daily.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="p-6 space-y-6">
+    <header class="flex items-center justify-between">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
+          {{ t('navigation.reportsDaily') }}
+        </h1>
+        <p class="text-gray-600 dark:text-gray-400 mt-1">
+          {{ t('reports.daily.overviewHint') }}
+        </p>
+      </div>
+    </header>
+
+    <UCard>
+      <div class="text-gray-600 dark:text-gray-300">
+        {{ t('reports.placeholder') }}
+      </div>
+    </UCard>
+  </div>
+</template>
+
+<script setup lang="ts">
+const { t } = useI18n();
+
+definePageMeta({
+  title: 'reportsDaily',
+  layout: 'default',
+});
+</script>

--- a/web-admin/app/pages/reports/monthly.vue
+++ b/web-admin/app/pages/reports/monthly.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="p-6 space-y-6">
+    <header class="flex items-center justify-between">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
+          {{ t('navigation.reportsMonthly') }}
+        </h1>
+        <p class="text-gray-600 dark:text-gray-400 mt-1">
+          {{ t('reports.monthly.overviewHint') }}
+        </p>
+      </div>
+    </header>
+
+    <UCard>
+      <div class="text-gray-600 dark:text-gray-300">
+        {{ t('reports.placeholder') }}
+      </div>
+    </UCard>
+  </div>
+</template>
+
+<script setup lang="ts">
+const { t } = useI18n();
+
+definePageMeta({
+  title: 'reportsMonthly',
+  layout: 'default',
+});
+</script>

--- a/web-admin/i18n/locales/en.json
+++ b/web-admin/i18n/locales/en.json
@@ -32,7 +32,10 @@
     "permissions": "Permissions",
     "profile": "Profile",
     "help": "Help",
-    "logout": "Logout"
+    "logout": "Logout",
+    "reports": "Reports",
+    "reportsDaily": "Daily Reports",
+    "reportsMonthly": "Monthly Reports"
   },
   "notes": {
     "title": "Notes Management",
@@ -100,5 +103,15 @@
     "noData": "No data available",
     "networkError": "Network error, please check your connection",
     "noteCreated": "Note created successfully"
+  },
+  "reports": {
+    "overviewHint": "Monitor overall performance with the latest report summaries.",
+    "placeholder": "Report data is being prepared. Connect your data sources to see insights here soon.",
+    "daily": {
+      "overviewHint": "Review today's performance metrics, highlights, and outstanding tasks."
+    },
+    "monthly": {
+      "overviewHint": "Track month-over-month trends and summarize key achievements."
+    }
   }
 }

--- a/web-admin/i18n/locales/zh.json
+++ b/web-admin/i18n/locales/zh.json
@@ -32,7 +32,10 @@
     "permissions": "权限管理",
     "profile": "个人资料",
     "help": "帮助",
-    "logout": "退出登录"
+    "logout": "退出登录",
+    "reports": "报表",
+    "reportsDaily": "日报表",
+    "reportsMonthly": "月报表"
   },
   "notes": {
     "title": "笔记管理",
@@ -84,7 +87,15 @@
     "cumulativeFlow": "累积流图",
     "sprintReport": "笔记报告",
     "teamPerformance": "团队绩效",
-    "productivity": "生产力分析"
+    "productivity": "生产力分析",
+    "overviewHint": "查看插件内置的报表概览，后续可对接真实数据。",
+    "placeholder": "报表数据准备中，请连接数据源后查看详细分析。",
+    "daily": {
+      "overviewHint": "掌握今日核心指标和任务进展。"
+    },
+    "monthly": {
+      "overviewHint": "总结本月的关键趋势与阶段成果。"
+    }
   },
   "settings": {
     "roleManagement": "角色管理",


### PR DESCRIPTION
## Summary
- add dedicated `/reports/daily` and `/reports/monthly` pages with placeholder content and proper Nuxt page meta
- extend zh/en i18n resources so navigation labels and report descriptions stay translated without hard-coded strings

## Testing
- npm run build *(fails: `nuxt` binary missing because dependencies cannot be installed in container)*
- npm install --no-progress *(fails: registry returned 403 for queue-micronote package)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b96b8800832581576f7d02a8543a